### PR TITLE
Trigger TagBot on issue comments, not cron

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,11 +1,20 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  contents: write
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.GHACTION_PRIV }}


### PR DESCRIPTION
It is no longer recommended to use cron jobs to trigger TagBot. Instead, one can use an issue comment trigger:
https://discourse.julialang.org/t/ann-required-updates-to-tagbot-yml/49249 