### PR TITLE
Handle non-Float and non-(concrete)Array input

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Additional functionality is provided via ChainRulesCore.jl to automatically diff
 
 The unique Nash equilibrium for the classic rock-paper-scissors game can be found as follows:
 ```julia
-julia> A = Float64[0 1 -1; -1 0 1; 1 -1 0];
+julia> A = [0 1 -1; -1 0 1; 1 -1 0];
 julia> B = -A;
 julia> compute_equilibrium([A, B]).x
 2-element Vector{Vector{Float64}}:

--- a/src/nash.jl
+++ b/src/nash.jl
@@ -89,6 +89,8 @@ struct Wrapper{L} <: Function
     num_primals::Cint
 end
 
+Wrapper(tensors::AbstractArray, args...) = Wrapper(convert.(Array{Float64}, tensors), args...)
+
 function (T::Wrapper)(n::Cint, x::Vector{Cdouble}, f::Vector{Cdouble})
     ind = 0
     for (n, tensor) ∈ enumerate(T.tensors)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,3 +6,4 @@ using Random: MersenneTwister
 
 include("test_equilibrium.jl")
 include("test_derivatives.jl")
+include("test_abstract_number_array_input.jl")

--- a/test/test_abstract_number_array_input.jl
+++ b/test/test_abstract_number_array_input.jl
@@ -9,7 +9,7 @@ end
 
 @testset "abstract array input" begin
     # Prisoner's dilemma using transpose
-    A = [2 0; 3 1]
+    A = [1 3; 0 2]
     B = A'
-    @test compute_equilibrium([A, B]).x == [[0, 1], [0, 1]]
+    @test compute_equilibrium([A, B]).x ≈ [[0, 1], [0, 1]]
 end

--- a/test/test_abstract_number_array_input.jl
+++ b/test/test_abstract_number_array_input.jl
@@ -1,0 +1,15 @@
+# The package should be able to handle input that is any abstract array of Numbers
+
+@testset "non-float input" begin
+    # Matching pennies with integers
+    A = [-1 1; 1 -1]
+    B = -A
+    @test compute_equilibrium([A, B]).x == [[0.5, 0.5], [0.5, 0.5]]
+end
+
+@testset "abstract array input" begin
+    # Prisoner's dilemma using transpose
+    A = [2 0; 3 1]
+    B = A'
+    @test compute_equilibrium([A, B]).x == [[0, 1], [0, 1]]
+end


### PR DESCRIPTION
Whenever I am using this in the command line, I want to use Ints and transposes. This allows the package to handle that by automatically converting to concrete Arrays of Floats
