### PR TITLE
Forward user interrupts

### DIFF
--- a/src/nash.jl
+++ b/src/nash.jl
@@ -251,6 +251,10 @@ function compute_equilibrium(cost_tensors;
         convergence_tolerance,
         silent)
 
+    if status === PATHSolver.MCP_UserInterrupt
+        throw(InterruptException())
+    end
+
     x = [vars[primal_indices[n, 1]:primal_indices[n, 2]] for n ∈ 1:N]
     λ = vars[dual_inds]
 


### PR DESCRIPTION
It can be difficult to interrupt the solver in a tight inner loop since the interrupts caught inside PATH (on the C side) never make it into Julia. [Since I couldn't convince the maintainers of PATHSolver.jl to forward the interrupts there](https://github.com/chkwon/PATHSolver.jl/pull/100), we have to do it here.